### PR TITLE
Invalid job for record

### DIFF
--- a/core/errors.py
+++ b/core/errors.py
@@ -2,6 +2,10 @@ from django.shortcuts import render
 
 from core.models import ErrorReport
 
+import logging
+import traceback
+
+LOGGER = logging.getLogger(__name__)
 
 class ErrorMiddleware():
     def __init__(self, get_response):
@@ -13,6 +17,7 @@ class ErrorMiddleware():
 
     @staticmethod
     def process_exception(request, exception):
+        LOGGER.debug(traceback.print_exc())
         report = ErrorReport.create(exception)
         report.save()
         return render(request, 'core/error.html', {'report': report})

--- a/core/models/transformation.py
+++ b/core/models/transformation.py
@@ -220,8 +220,8 @@ class Transformation(models.Model):
             # handle empty, global namespace
             _nsmap = xsl.nsmap.copy()
             try:
-                _nsmap.pop(None)
-                _nsmap['global_ns'] = ns0
+                global_ns = _nsmap.pop(None)
+                _nsmap['global_ns'] = global_ns
             except:
                 pass
 

--- a/core/views/datatables.py
+++ b/core/views/datatables.py
@@ -175,7 +175,7 @@ class DTRecordsJson(BaseDatatableView):
 
     def get_initial_queryset(self):
 
-        # return queryset used as base for futher sorting/filtering
+        # return queryset used as base for further sorting/filtering
 
         # if job present, filter by job
         if 'job_id' in self.kwargs.keys():
@@ -191,7 +191,9 @@ class DTRecordsJson(BaseDatatableView):
             return job.get_records(success=success_filter)
 
         # else, return all records
-        return Record.objects
+        job_ids = list(map(lambda j: j.id, Job.objects.all()))
+        records = Record.objects.filter(job_id__in=job_ids)
+        return records
 
     def render_column(self, row, column):
 
@@ -199,7 +201,8 @@ class DTRecordsJson(BaseDatatableView):
         record_link = reverse(record, kwargs={
             'org_id': row.job.record_group.organization.id,
             'record_group_id': row.job.record_group.id,
-            'job_id': row.job.id, 'record_id': str(row.id)
+            'job_id': row.job.id,
+            'record_id': str(row.id)
         })
 
         # handle db_id
@@ -257,7 +260,7 @@ class DTRecordsJson(BaseDatatableView):
                     oid = ObjectId(search)
                     qs = qs.filter(mongoengine.Q(id=oid))
                 except:
-                    LOGGER.debug('recieved 24 chars, but not ObjectId')
+                    LOGGER.debug('received 24 chars, but not ObjectId')
             else:
                 qs = qs.filter(mongoengine.Q(record_id=search))
 

--- a/tests/test_models/test_record.py
+++ b/tests/test_models/test_record.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+
+from core.models import Record
+
+class RecordModelTestCase(TestCase):
+
+    def test_record_with_nonexistent_job(self):
+        record = Record(job_id=2345789)
+        self.assertEqual(record.job.name, 'No Job')
+        self.assertEqual(record.job.record_group, 'No Record Group')

--- a/tests/test_views/test_records_datatable.py
+++ b/tests/test_views/test_records_datatable.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+
+from core.views import DTRecordsJson
+from core.models import Record
+from tests.utils import TestConfiguration
+
+class DTRecordsTestCase(TestCase):
+    def test_get_initial_queryset(self):
+        config = TestConfiguration()
+        other_record = Record(job_id=9348275987)
+        view = DTRecordsJson(kwargs={})
+        records = view.get_initial_queryset()
+        job_ids = set(map(lambda x: x.job.id, records))
+        self.assertNotIn(0, job_ids)


### PR DESCRIPTION
Trying to load a Record with an invalid Job ID into the datatable, such as on the 'Test Transformation' page, caused the UI to break and not allow any records to be seen.

I implemented two solutions:
(1) a 'MissingJob' object
(2) only loading records with valid job_ids for the datatable

Resolves #426 